### PR TITLE
Use new gribjump interator api

### DIFF
--- a/src/zfdb/datasources.py
+++ b/src/zfdb/datasources.py
@@ -267,7 +267,7 @@ class FdbSource(DataSource):
         ]
         buffer = np.zeros(self._chunks, dtype="float32")
         for idx, field in enumerate(itertools.chain.from_iterable(gj_results)):
-            buffer[0, idx, 0, :] = field[0][0][0]
+            buffer[0, idx, 0, :] = field.values
         return CpuBuffer.from_bytes(np.ravel(buffer).view(dtype="b"))
 
 


### PR DESCRIPTION
Updates the unpacking of gribjump.extract output, as gribjump will shortly be updated to return an iterator of "ExtractionResult" objects, rather than the horrific list of lists of lists of <...>.

I suggest not merging until the corresponding branch is merged/released on gribjump https://github.com/ecmwf/gribjump/pull/49 . Should be in the next day or two